### PR TITLE
Use SQLAlchemy instead of raw SQL

### DIFF
--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -1,18 +1,32 @@
-from sqlalchemy import create_engine, AsyncSession 
+from sqlalchemy import create_engine, create_async_engine, sessionmaker, AsyncSession
 from sqlalchemy.orm import declarative_base
 from .config import settings
 
 DATABASE_URL = settings.POSTGRES_DB_URL
+NEON_DATABASE_URL = f"postgresql+asyncpg://{settings.NEOND_DB_USER}:{settings.NEOND_DB_PASSWORD}@{settings.NEOND_DB_HOST}/{settings.NEOND_DB_NAME}"
 
-engine = create_async_engine(DATABASE_URL) 
-AsyncSessionLocal = sessionmaker( 
-    bind=engine, class_=AsyncSession, expire_on_commit=False 
+engine = create_async_engine(DATABASE_URL)
+neon_engine = create_async_engine(NEON_DATABASE_URL)
+
+AsyncSessionLocal = sessionmaker(
+    bind=engine, class_=AsyncSession, expire_on_commit=False
+)
+
+NeonAsyncSessionLocal = sessionmaker(
+    bind=neon_engine, class_=AsyncSession, expire_on_commit=False
 )
 
 Base = declarative_base()
 
 def get_db():
     db = AsyncSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+def get_neon_db():
+    db = NeonAsyncSessionLocal()
     try:
         yield db
     finally:

--- a/backend/app/models/db_models.py
+++ b/backend/app/models/db_models.py
@@ -77,3 +77,12 @@ class ChatSessionPDF(Base):
 
     chat_session = relationship("ChatSession", back_populates="pdf_documents_assoc")
     pdf_document = relationship("PDFDocument", back_populates="chat_sessions_assoc")
+
+class DocumentChunk(Base):
+    __tablename__ = "document_chunks"
+
+    id = Column(Integer, primary_key=True, index=True)
+    chunk_text = Column(String)
+    embedding = Column(LargeBinary)
+    metadata = Column(String)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())

--- a/backend/app/services/neon_service.py
+++ b/backend/app/services/neon_service.py
@@ -1,107 +1,30 @@
-import asyncpg
 import json
 from fastapi import HTTPException
-from app.core.config import settings
+from sqlalchemy.orm import Session
+from app.models.db_models import DocumentChunk
 import logging
 
 logger = logging.getLogger(__name__)
 
-async def get_neon_connection():
-    try:
-        connection = await asyncpg.connect(
-            user=settings.NEOND_DB_USER,
-            password=settings.NEOND_DB_PASSWORD,
-            database=settings.NEOND_DB_NAME,
-            host=settings.NEOND_DB_HOST
-        )
-        return connection
-    except Exception as e:
-        logger.error(f"Error searching NeonDB: {str(e)}", exc_info=True)
-        raise HTTPException(status_code=500, detail=f"Database connection error: {str(e)}")
-
-async def search_neon_chunks(query_embedding: list, top_n: int = 5):
+async def search_neon_chunks(db: Session, query_embedding: list, top_n: int = 5):
     """
-    Searches NeonDB for similar chunks.
-    Now returns chunk_text and a potential ID (if you store one in NeonDB, adjust query if needed).
+    Searches NeonDB for similar chunks using SQLAlchemy ORM.
     """
-    conn = await get_neon_connection()
     try:
-        search_query = """
-            SELECT chunk_text -- , chunk_id  -- If you have chunk_id in NeonDB
-            FROM document_chunks -- Ensure this table exists in NeonDB
-            SELECT chunk_text, metadata
-            FROM document_chunks
-             ORDER BY embedding <=> $1
-             LIMIT $2;
-         """
-        # Base query without filters
-        if not pdf_ids and not user_id:
-            search_query = """
-                SELECT chunk_text, metadata
-                FROM document_chunks
-                ORDER BY embedding <=> $1
-                LIMIT $2;
-            """
-            results = await conn.fetch(search_query, json.dumps(query_embedding), top_n)
+        results = db.query(DocumentChunk).order_by(DocumentChunk.embedding.op('<=>')(query_embedding)).limit(top_n).all()
 
-        # Query with PDF filter
-        elif pdf_ids:
-            pdf_ids_str = ','.join(str(id) for id in pdf_ids)
-            search_query = """
-                SELECT chunk_text, metadata
-                FROM document_chunks
-                WHERE metadata->>'pdf_document_id' = ANY($3::text[])
-                ORDER BY embedding <=> $1
-                LIMIT $2;
-            """
-            results = await conn.fetch(
-                search_query,
-                json.dumps(query_embedding),
-                top_n,
-                [str(id) for id in pdf_ids]
-            )
-
-        # Query with user filter (adjust if you store user_id directly in document_chunks metadata)
-        elif user_id:
-            # ASSUMPTION: You store 'user_id' in the metadata of document_chunks
-            search_query = """
-                SELECT chunk_text, metadata
-                FROM document_chunks
-                WHERE metadata->>'user_id' = $3
-                ORDER BY embedding <=> $1
-                LIMIT $2;
-            """
-            results = await conn.fetch(
-                search_query,
-                json.dumps(query_embedding),
-                top_n,
-                str(user_id) # Assuming user_id is stored as string in metadata
-            )
-        else: # Base query if no filters are provided
-            search_query = """
-                SELECT chunk_text, metadata
-                FROM document_chunks
-                ORDER BY embedding <=> $1
-                LIMIT $2;
-            """
-            results = await conn.fetch(search_query, json.dumps(query_embedding), top_n)
-
-        # Process results
         chunks = []
         for row in results:
-            chunk_text = row['chunk_text']
-            metadata = json.loads(row['metadata']) if row['metadata'] else {}
+            chunk_text = row.chunk_text
+            metadata = json.loads(row.metadata) if row.metadata else {}
 
-            # Optionally include metadata in the results - adjust as needed
-            source = metadata.get('filename', 'Unknown Source') # Example: filename from metadata
-            page = metadata.get('page', 'Unknown Page') # Example: page number from metadata (if you store it)
-            formatted_chunk = f"[Source: {source}, Page: {page}]\n{chunk_text}" # Example formatting
+            source = metadata.get('filename', 'Unknown Source')
+            page = metadata.get('page', 'Unknown Page')
+            formatted_chunk = f"[Source: {source}, Page: {page}]\n{chunk_text}"
             chunks.append(formatted_chunk)
 
-        results = await conn.fetch(search_query, json.dumps(query_embedding), top_n)
-        return [row['chunk_text'] for row in results] # Or return more if needed
+        return chunks
 
     except Exception as e:
+        logger.error(f"Error searching NeonDB: {str(e)}", exc_info=True)
         raise HTTPException(status_code=500, detail=f"Error searching NeonDB: {str(e)}")
-    finally:
-        await conn.close()


### PR DESCRIPTION
Refactor NeonDB interactions to use SQLAlchemy instead of raw SQL queries.

* **`backend/app/services/neon_service.py`**:
  - Remove `get_neon_connection` function.
  - Update `search_neon_chunks` function to use SQLAlchemy ORM queries.

* **`backend/app/services/pdf_service.py`**:
  - Update `store_chunk_to_neondb` function to use SQLAlchemy ORM queries.
  - Modify `process_pdf_and_store` function to include `db` dependency and use SQLAlchemy ORM.

* **`backend/app/models/db_models.py`**:
  - Add `DocumentChunk` model to represent `document_chunks` table in NeonDB.

* **`backend/app/core/database.py`**:
  - Add new engine and session for NeonDB using SQLAlchemy.
  - Add `get_neon_db` function for NeonDB session management.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Ad1tyaNarayana/perplexia/pull/1?shareId=f3baad96-49e4-4f19-9575-91d0a8fea4b3).